### PR TITLE
persist and restore layout manually

### DIFF
--- a/core/config.lua
+++ b/core/config.lua
@@ -14,7 +14,7 @@ nekometer.meters = {
 
 nekometer.defaults = {
     -- version (increment to force wipe on init)
-    configVersion = 12,
+    configVersion = 13,
 
     -- general
     updateRate = 0.5,
@@ -38,6 +38,14 @@ nekometer.defaults = {
     windowLocked = false,
     windowMinWidth = 235,
     windowMinHeight = 80,
+    windowLayout = {
+        point = "CENTER",
+        relativePoint = "CENTER",
+        x = 0,
+        y = 0,
+        w = 260,
+        h = 80,
+    },
     windowColor = {
         r = 0,
         g = 0,

--- a/ui/main.lua
+++ b/ui/main.lua
@@ -4,23 +4,9 @@ local _, nekometer = ...
 local frame = CreateFrame("Frame", "NekometerMainFrame", UIParent, "BackdropTemplate")
 
 function frame:Init()
-    self:SetPoint("CENTER")
-    self:SetClampedToScreen(true)
-    self:SetWidth(NekometerConfig.windowMinWidth)
-    self:SetHeight(NekometerConfig.windowMinHeight)
-    self:SetBackdrop({
-        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
-        tile = true,
-        tileSize = 16,
-    })
-    local c = NekometerConfig.windowColor
-    self:SetBackdropColor(c.r, c.g, c.b, c.a)
-    self:EnableMouse(true)
-    self:SetMovable(true)
-    self:SetResizable(true)
-    self:SetResizeBounds(NekometerConfig.windowMinWidth, NekometerConfig.windowMinHeight)
-    self:SetScript("OnUpdate", self.OnUpdate)
-    self:SetScript("OnMouseWheel", self.OnMouseWheel)
+    self:RestoreLayout()
+    self:EnableMoveAndResize()
+    self:SetBackground()
     self:SetShown(NekometerConfig.windowShown and not NekometerConfig.autoHide)
 end
 
@@ -91,6 +77,47 @@ function frame:OnMouseWheel(delta)
     else
         barContainer:ScrollDown()
     end
+end
+
+function frame:SaveLayout()
+    local point, _, relativePoint, x, y = frame:GetPoint()
+    local w = frame:GetWidth()
+    local h = frame:GetHeight()
+    NekometerConfig.windowLayout = {
+        point = point,
+        relativePoint = relativePoint,
+        x = x,
+        y = y,
+        w = w,
+        h = h,
+    }
+end
+
+function frame:RestoreLayout()
+    local layout = NekometerConfig.windowLayout
+    self:SetPoint(layout.point, nil, layout.relativePoint, layout.x, layout.y)
+    self:SetSize(layout.w, layout.h)
+end
+
+function frame:EnableMoveAndResize()
+    self:SetClampedToScreen(true)
+    self:RegisterForDrag("LeftButton")
+    self:SetMovable(true)
+    self:EnableMouse(true)
+    self:SetResizable(true)
+    self:SetResizeBounds(NekometerConfig.windowMinWidth, NekometerConfig.windowMinHeight)
+    self:SetScript("OnUpdate", self.OnUpdate)
+    self:SetScript("OnMouseWheel", self.OnMouseWheel)
+end
+
+function frame:SetBackground()
+    local c = NekometerConfig.windowColor
+    frame:SetBackdrop({
+        bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+        tile = true,
+        tileSize = 16,
+    })
+    frame:SetBackdropColor(c.r, c.g, c.b, c.a)
 end
 
 nekometer.frames = nekometer.frames or {}

--- a/ui/titlebar.lua
+++ b/ui/titlebar.lua
@@ -50,14 +50,15 @@ end)
 frame:SetScript("OnMouseUp", function(_, button)
     if button == "LeftButton" then
         mainFrame:StopMovingOrSizing()
+        mainFrame:SaveLayout()
     end
 end)
 
 function frame:Update()
     local meter = mainFrame:GetCurrentMeter()
-    frame.titleText:SetText(meter.title)
     local mode = nekometer.getMode(meter.key)
-    frame:UpdateModeButton(mode)
+    self.titleText:SetText(meter.title)
+    self:UpdateModeButton(mode)
 end
 
 


### PR DESCRIPTION
This prevents the layout from being reset when the addon is disabled and then re-enabled.
Fixes #43 