### PR TITLE
[Mists Classic] Use fallback color for pet units (take 2)

### DIFF
--- a/core/util.lua
+++ b/core/util.lua
@@ -43,11 +43,14 @@ function util:IsClassic()
 end
 
 function util:GetClassColor(class)
-    if C_ClassColor and C_ClassColor.GetClassColor then
-        return C_ClassColor.GetClassColor(class)
-    elseif _G.RAID_CLASS_COLORS then
-        local UNKNOWN_COLOR = CreateColor(.75,.75,.75,1)
-        return (CUSTOM_CLASS_COLORS or RAID_CLASS_COLORS)[class] or UNKNOWN_COLOR
+    if class == "PET" then
+        return NekometerConfig.barNeutralColor
+    else
+        if C_ClassColor and C_ClassColor.GetClassColor then
+            return C_ClassColor.GetClassColor(class)
+        elseif _G.RAID_CLASS_COLORS then
+            return (CUSTOM_CLASS_COLORS or RAID_CLASS_COLORS)[class]
+        end
     end
 end
 

--- a/nekometer.toc
+++ b/nekometer.toc
@@ -1,5 +1,5 @@
-## Interface: 50503, 20505, 11508, 50504
-## Version: 2.6.1
+## Interface: 50504, 20505, 11508
+## Version: 2.6.2
 ## SavedVariables: NekometerConfig
 ## Title: Nekometer
 ## Notes: minimalistic damage meter

--- a/ui/bars/bar.lua
+++ b/ui/bars/bar.lua
@@ -53,12 +53,11 @@ function bar:setColor(id)
         local class = nekometer.classes:Lookup(id)
         if class then
             c = util:GetClassColor(class)
-            c.a = 0.6
         else
             c = NekometerConfig.barNeutralColor
         end
     end
-    self.frame:SetColorFill(c.r, c.g, c.b, c.a)
+    self.frame:SetColorFill(c.r, c.g, c.b, class and 0.6 or c.a)
 end
 
 nekometer.bars = nekometer.bars or {}


### PR DESCRIPTION
bugfix: use neutral bar color config option as fallback color for pets
maintenance: metadata update, compatible with mists classic 5.5.4, up patch version